### PR TITLE
lodash is a dependency, not a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "tasks"
   ],
   "dependencies": {
+    "lodash": "2.4.1",
     "ng-annotate": "~0.15.1"
   },
   "devDependencies": {
@@ -43,7 +44,6 @@
     "grunt-mocha-test": "0.12.7",
     "jscs-trailing-comma": "0.3.0",
     "load-grunt-tasks": "2.0.0",
-    "lodash": "2.4.1",
     "mocha": "2.1.0",
     "time-grunt": "1.0.0"
   },


### PR DESCRIPTION
lodash is not a dev dependency, it is used https://github.com/mzgol/grunt-ng-annotate/blob/master/tasks/ng-annotate.js#L12