### PR TITLE
file concat separator

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -96,6 +96,17 @@ module.exports = function (grunt) {
                     ],
                 },
             },
+            srcDestSeparator: {
+                options: {
+                    separator: ';',
+                },
+                files: {
+                    'test/tmp/concatenated-separator.js': [
+                        'test/tmp/not-annotated.js',
+                        'test/tmp/annotated.js',
+                    ],
+                },
+            },
             singleQuotes: {
                 options: {
                     add: true,

--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ Type: `boolean`
 
 Default: `false`
 
+### separator
+
+Type: `String`
+
+Default: `grunt.util.linefeed`
+
+Concatenated files will be joined on this string. 
+
 ### sourceMap
 
 Enables source map generation.

--- a/README.md
+++ b/README.md
@@ -78,11 +78,13 @@ Default: `false`
 
 ### separator
 
-Type: `String`
+Concatenated files will be joined on this string. 
+
+Type: `string`
 
 Default: `grunt.util.linefeed`
 
-Concatenated files will be joined on this string. 
+If you're post-processing concatenated JavaScript files with a minifier, you may need to use a semicolon ';' as the separator.
 
 ### sourceMap
 

--- a/tasks/ng-annotate.js
+++ b/tasks/ng-annotate.js
@@ -51,6 +51,11 @@ module.exports = function (grunt) {
             delete options.singleQuotes;
         }
 
+        if (options.separator != null) {
+            options.ngAnnotateOptions.separator = options.separator;
+            delete options.separator;
+        }
+
         if (options.sourceMap) {
             sourceMapOptions = options.ngAnnotateOptions.sourcemap = {};
             sourceMapOptions.inline = options.sourceMap === true;
@@ -151,9 +156,13 @@ module.exports = function (grunt) {
                     ngAnnotateOptions.sourcemap.inFile = getPathFromTo(mapping.dest, mapping.src[0]);
                 }
 
+                var separator = (typeof ngAnnotateOptions.separator === 'string') ?
+                        ngAnnotateOptions.separator + '\n' :
+                        '\n';
+
                 var concatenatedSource = mapping.src.map(function (file) {
                     return grunt.file.read(file);
-                }).join(';\n');
+                }).join(separator);
 
                 var ngAnnotateOutput = ngAnnotate(concatenatedSource, ngAnnotateOptions);
 

--- a/tasks/ng-annotate.js
+++ b/tasks/ng-annotate.js
@@ -156,9 +156,10 @@ module.exports = function (grunt) {
                     ngAnnotateOptions.sourcemap.inFile = getPathFromTo(mapping.dest, mapping.src[0]);
                 }
 
+                // seperator for file concatenation; defaults to linefeed
                 var separator = (typeof ngAnnotateOptions.separator === 'string') ?
-                        ngAnnotateOptions.separator + '\n' :
-                        '\n';
+                        ngAnnotateOptions.separator :
+                        grunt.util.linefeed;
 
                 var concatenatedSource = mapping.src.map(function (file) {
                     return grunt.file.read(file);

--- a/test/fixtures/concatenated-separator.js
+++ b/test/fixtures/concatenated-separator.js
@@ -31,8 +31,7 @@
         };
     }]);
 })();
-;
-(function () {
+;(function () {
     "use strict";
 
     angular.module("app", ["dep1", "dep2"])

--- a/test/fixtures/concatenated-separator.js
+++ b/test/fixtures/concatenated-separator.js
@@ -31,7 +31,7 @@
         };
     }]);
 })();
-
+;
 (function () {
     "use strict";
 

--- a/test/spec/api.js
+++ b/test/spec/api.js
@@ -50,6 +50,10 @@ describe('grunt-ng-annotate API', function () {
         expect(readTmp('concatenated.js')).to.be(readFix('concatenated.js'));
     });
 
+    it('should concatenate source files with separator and save to destination path', function () {
+        expect(readTmp('concatenated-separator.js')).to.be(readFix('concatenated-separator.js'));
+    });
+
     it('should respect the `singleQuotes` setting', function () {
         expect(readTmp('not-annotated-singlequotes.js')).to.be(readFix('annotated-single.js'));
     });


### PR DESCRIPTION
This closed issue requested a defensive semicolon insertion during concatenation:

https://github.com/mzgol/grunt-ng-annotate/issues/22

This was a breaking change for my build process so I have implemented a setting for this.

It's a setting called "separator" in imitation of the same setting in grunt-contrib-concat.

Hopefully this is acceptable.